### PR TITLE
Add goreleaser and tagpr for automated releases

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -14,10 +14,10 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
     - name: Set up Go
-      uses: actions/setup-go@v4
+      uses: actions/setup-go@7b8cf10d4e4a01d4992d18a89f4d7dc5a3e6d6f4 # v4.3.0
       with:
         go-version: '1.24'
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,15 +12,15 @@ jobs:
   goreleaser:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           fetch-depth: 0
 
-      - uses: actions/setup-go@v5
+      - uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5.6.0
         with:
           go-version-file: go.mod
 
-      - uses: goreleaser/goreleaser-action@v6
+      - uses: goreleaser/goreleaser-action@e435ccd777264be153ace6237001ef4d979d3a7a # v6.4.0
         with:
           version: "~> v2"
           args: release --clean

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,28 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - "v*"
+
+permissions:
+  contents: write
+
+jobs:
+  goreleaser:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+
+      - uses: goreleaser/goreleaser-action@v6
+        with:
+          version: "~> v2"
+          args: release --clean
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/tagpr.yml
+++ b/.github/workflows/tagpr.yml
@@ -1,0 +1,20 @@
+name: tagpr
+
+on:
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  tagpr:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: Songmu/tagpr@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/tagpr.yml
+++ b/.github/workflows/tagpr.yml
@@ -13,8 +13,16 @@ jobs:
   tagpr:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/create-github-app-token@d72941d797fd3113feb6b93fd0dec494b13a2547 # v1.12.0
+        id: app-token
+        with:
+          app-id: ${{ vars.TAGPR_APP_ID }}
+          private-key: ${{ secrets.TAGPR_APP_PRIVATE_KEY }}
 
-      - uses: Songmu/tagpr@v1
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          token: ${{ steps.app-token.outputs.token }}
+
+      - uses: Songmu/tagpr@da82ed6743aec90049892070edd5561335904a9e # v1.17.0
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -1,0 +1,26 @@
+version: 2
+
+builds:
+  - main: .
+    binary: mieta
+    env:
+      - CGO_ENABLED=0
+    goos:
+      - linux
+      - darwin
+      - windows
+    goarch:
+      - amd64
+      - arm64
+
+archives:
+  - format_overrides:
+      - goos: windows
+        format: zip
+
+changelog:
+  sort: asc
+  filters:
+    exclude:
+      - "^docs:"
+      - "^test:"

--- a/.tagpr
+++ b/.tagpr
@@ -1,0 +1,3 @@
+# config file for the tagpr in git config format
+[tagpr]
+	releaseBranch = main


### PR DESCRIPTION
## Summary
- Add `.goreleaser.yaml` for cross-platform binary builds (Linux/macOS/Windows × amd64/arm64)
- Add GitHub Actions workflow to run goreleaser on `v*` tag push
- Add GitHub Actions workflow to run tagpr on main branch push for automated version PRs

## Test plan
- [ ] Verify goreleaser config with `goreleaser check` (or wait for first tag push)
- [ ] Merge and confirm tagpr creates a version bump PR
- [ ] Merge the version PR and confirm goreleaser creates a GitHub Release

🤖 Generated with [Claude Code](https://claude.com/claude-code)